### PR TITLE
Add default user code and fixuid tool and config

### DIFF
--- a/.github/prompts/update-project.prompt.md
+++ b/.github/prompts/update-project.prompt.md
@@ -100,6 +100,7 @@ All three Dockerfiles share the same versions for the following builder-stage to
 `composer/composer`
 - `XDEBUG_VERSION` — `xdebug/xdebug` on Packagist
 - `PCOV_VERSION` — `pecl/pcov` on Packagist
+- `FIXUID_VERSION` — check the GitHub Releases API for `boxboat/fixuid`
 
 Process each tool individually and in order:
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -186,6 +186,50 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/*
 
+# Latest version of fixuid: https://github.com/boxboat/fixuid/releases/latest
+ARG FIXUID_VERSION=0.6.0
+
+ARG USER=code
+ARG GROUP=code
+ARG USER_UID=1000
+ARG USER_GID=1000
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSLo /tmp/fixuid.tar.gz "https://github.com/boxboat/fixuid/releases/download/v$FIXUID_VERSION/fixuid-${FIXUID_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    && tar -xf /tmp/fixuid.tar.gz -C /usr/local/bin fixuid \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && rm /tmp/fixuid.tar.gz \
+    # Create user and group, and setup fixuid configuration
+    && existing_group="$(getent group "$USER_GID" | cut -d: -f1 || true)" \
+    && if [ -z "$existing_group" ]; then \
+           groupadd --gid "$USER_GID" "$GROUP"; \
+           existing_group="$GROUP"; \
+       fi \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" --create-home "$USER" --shell /bin/bash \
+    && mkdir -p \
+        /etc/fixuid \
+        "/data" \
+        "/config" \
+        "/cache" \
+    && chown -R "$USER_UID":"$USER_GID" \
+        "/data" \
+        "/config" \
+        "/cache" \
+    && cat <<EOF > /etc/fixuid/config.yml
+user: $USER
+group: $existing_group
+paths:
+  - /var/www
+  - /home/$USER
+  - /data
+  - /config
+  - /cache
+
+EOF
+
 FROM builder AS builder_nodejs
 
 ARG TARGETARCH

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -149,6 +149,7 @@ ARG XDEBUG_VERSION=3.5.1
 # Latest version of pcov: https://packagist.org/packages/pecl/pcov
 ARG PCOV_VERSION=1.0.12
 
+
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         # Needed for xdebug extension configuration
@@ -185,6 +186,50 @@ RUN apt-get update \
     && apt-get clean --assume-yes \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/*
+
+# Latest version of fixuid: https://github.com/boxboat/fixuid/releases/latest
+ARG FIXUID_VERSION=0.6.0
+
+ARG USER=code
+ARG GROUP=code
+ARG USER_UID=1000
+ARG USER_GID=1000
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSLo /tmp/fixuid.tar.gz "https://github.com/boxboat/fixuid/releases/download/v$FIXUID_VERSION/fixuid-${FIXUID_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    && tar -xf /tmp/fixuid.tar.gz -C /usr/local/bin fixuid \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && rm /tmp/fixuid.tar.gz \
+    # Create user and group, and setup fixuid configuration
+    && existing_group="$(getent group "$USER_GID" | cut -d: -f1 || true)" \
+    && if [ -z "$existing_group" ]; then \
+           groupadd --gid "$USER_GID" "$GROUP"; \
+           existing_group="$GROUP"; \
+       fi \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" --create-home "$USER" --shell /bin/bash \
+    && mkdir -p \
+        /etc/fixuid \
+        "/data" \
+        "/config" \
+        "/cache" \
+    && chown -R "$USER_UID":"$USER_GID" \
+        "/data" \
+        "/config" \
+        "/cache" \
+    && cat <<EOF > /etc/fixuid/config.yml
+user: $USER
+group: $existing_group
+paths:
+  - /var/www
+  - /home/$USER
+  - /data
+  - /config
+  - /cache
+
+EOF
 
 FROM builder AS builder_nodejs
 

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -190,6 +190,50 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/*
 
+# Latest version of fixuid: https://github.com/boxboat/fixuid/releases/latest
+ARG FIXUID_VERSION=0.6.0
+
+ARG USER=code
+ARG GROUP=code
+ARG USER_UID=1000
+ARG USER_GID=1000
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSLo /tmp/fixuid.tar.gz "https://github.com/boxboat/fixuid/releases/download/v$FIXUID_VERSION/fixuid-${FIXUID_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    && tar -xf /tmp/fixuid.tar.gz -C /usr/local/bin fixuid \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && rm /tmp/fixuid.tar.gz \
+    # Create user and group, and setup fixuid configuration
+    && existing_group="$(getent group "$USER_GID" | cut -d: -f1 || true)" \
+    && if [ -z "$existing_group" ]; then \
+           groupadd --gid "$USER_GID" "$GROUP"; \
+           existing_group="$GROUP"; \
+       fi \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" --create-home "$USER" --shell /bin/bash \
+    && mkdir -p \
+        /etc/fixuid \
+        "/data" \
+        "/config" \
+        "/cache" \
+    && chown -R "$USER_UID":"$USER_GID" \
+        "/data" \
+        "/config" \
+        "/cache" \
+    && cat <<EOF > /etc/fixuid/config.yml
+user: $USER
+group: $existing_group
+paths:
+  - /var/www
+  - /home/$USER
+  - /data
+  - /config
+  - /cache
+
+EOF
+
 FROM builder AS builder_nodejs
 
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

- Adds fixuid tool installation and configuration to all three Dockerfiles (apache, fpm, frankenphp)
- Creates a default `code` user/group (UID/GID 1000) with fixuid set up to remap UIDs at runtime
- Adds `FIXUID_VERSION` to the update-project prompt for version tracking