### PR TITLE
Replace arduino/setup-task with official go-task/setup-task

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,10 +21,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
           version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate Dockerfiles
         run: task generate


### PR DESCRIPTION
## Summary
- Swap `arduino/setup-task@v2` for the official `go-task/setup-task@v2` action in the PR workflow's Dockerfile template check