### PR TITLE
Fix php-extension-installer dependabot tracking and update version-check links

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -2,7 +2,7 @@
 # check=error=true
 
 # Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
-FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of {{ .image_label }}: {{ .image_url }}
 FROM {{ getenv "BASE_IMAGE" }} AS runtime

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
+# Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
+FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+
 # Latest version of {{ .image_label }}: {{ .image_url }}
 FROM {{ getenv "BASE_IMAGE" }} AS runtime
 
@@ -30,7 +33,7 @@ ENV FRANKENPHP_CONFIG=""
 {{ end }}
 WORKDIR /var/www
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         apt-transport-https \
@@ -79,7 +82,7 @@ ARG XDEBUG_VERSION=3.5.3
 # Latest version of pcov: https://packagist.org/packages/pecl/pcov
 ARG PCOV_VERSION=1.0.12
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         vim \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -18,13 +18,13 @@ ENV XDG_DATA_HOME=$XDG_DATA_HOME
 ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
-# Latest version of event-extension: https://packagist.org/packages/osmanov/pecl-event
+# Latest version of event-extension: https://pecl.php.net/package/event
 ARG PHP_EVENT_VERSION=3.1.4
-# Latest version of igbinary-extension: https://packagist.org/packages/igbinary/igbinary
+# Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
-# Latest version of redis-extension: https://packagist.org/packages/phpredis/phpredis
+# Latest version of redis-extension: https://pecl.php.net/package/redis
 ARG PHP_REDIS_VERSION=6.3.0
-# Latest version of amqp-extension: https://packagist.org/packages/php-amqp/php-amqp
+# Latest version of amqp-extension: https://pecl.php.net/package/amqp
 ARG PHP_AMQP_VERSION=2.2.0
 {{ if .is_frankenphp }}
 # Default to classic mode (no workers). To enable worker mode, set:
@@ -77,9 +77,9 @@ FROM runtime AS builder
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Latest version of Xdebug: https://packagist.org/packages/xdebug/xdebug
+# Latest version of Xdebug: https://pecl.php.net/package/xdebug
 ARG XDEBUG_VERSION=3.5.3
-# Latest version of pcov: https://packagist.org/packages/pecl/pcov
+# Latest version of pcov: https://pecl.php.net/package/pcov
 ARG PCOV_VERSION=1.0.12
 
 RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -149,7 +149,7 @@ tasks:
     internal: true
     vars:
       BASE_IMAGE:
-        sh: awk '/^FROM / && !found { print $2; found=1 }' {{.VARIANT}}/Dockerfile
+        sh: awk '/^FROM .* AS runtime$/ { print $2; exit }' {{.VARIANT}}/Dockerfile
     cmds:
       - docker run
         --rm

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -2,7 +2,7 @@
 # check=error=true
 
 # Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
-FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of PHP base image: https://hub.docker.com/_/php/tags
 FROM php:8.4.22-apache-trixie AS runtime

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -18,13 +18,13 @@ ENV XDG_DATA_HOME=$XDG_DATA_HOME
 ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
-# Latest version of event-extension: https://packagist.org/packages/osmanov/pecl-event
+# Latest version of event-extension: https://pecl.php.net/package/event
 ARG PHP_EVENT_VERSION=3.1.4
-# Latest version of igbinary-extension: https://packagist.org/packages/igbinary/igbinary
+# Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
-# Latest version of redis-extension: https://packagist.org/packages/phpredis/phpredis
+# Latest version of redis-extension: https://pecl.php.net/package/redis
 ARG PHP_REDIS_VERSION=6.3.0
-# Latest version of amqp-extension: https://packagist.org/packages/php-amqp/php-amqp
+# Latest version of amqp-extension: https://pecl.php.net/package/amqp
 ARG PHP_AMQP_VERSION=2.2.0
 
 WORKDIR /var/www
@@ -71,9 +71,9 @@ FROM runtime AS builder
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Latest version of Xdebug: https://packagist.org/packages/xdebug/xdebug
+# Latest version of Xdebug: https://pecl.php.net/package/xdebug
 ARG XDEBUG_VERSION=3.5.3
-# Latest version of pcov: https://packagist.org/packages/pecl/pcov
+# Latest version of pcov: https://pecl.php.net/package/pcov
 ARG PCOV_VERSION=1.0.12
 
 RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
+# Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
+FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+
 # Latest version of PHP base image: https://hub.docker.com/_/php/tags
 FROM php:8.4.22-apache-trixie AS runtime
 
@@ -26,7 +29,7 @@ ARG PHP_AMQP_VERSION=2.2.0
 
 WORKDIR /var/www
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         apt-transport-https \
@@ -73,7 +76,7 @@ ARG XDEBUG_VERSION=3.5.3
 # Latest version of pcov: https://packagist.org/packages/pecl/pcov
 ARG PCOV_VERSION=1.0.12
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         vim \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -18,13 +18,13 @@ ENV XDG_DATA_HOME=$XDG_DATA_HOME
 ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
-# Latest version of event-extension: https://packagist.org/packages/osmanov/pecl-event
+# Latest version of event-extension: https://pecl.php.net/package/event
 ARG PHP_EVENT_VERSION=3.1.4
-# Latest version of igbinary-extension: https://packagist.org/packages/igbinary/igbinary
+# Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
-# Latest version of redis-extension: https://packagist.org/packages/phpredis/phpredis
+# Latest version of redis-extension: https://pecl.php.net/package/redis
 ARG PHP_REDIS_VERSION=6.3.0
-# Latest version of amqp-extension: https://packagist.org/packages/php-amqp/php-amqp
+# Latest version of amqp-extension: https://pecl.php.net/package/amqp
 ARG PHP_AMQP_VERSION=2.2.0
 
 WORKDIR /var/www
@@ -71,9 +71,9 @@ FROM runtime AS builder
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Latest version of Xdebug: https://packagist.org/packages/xdebug/xdebug
+# Latest version of Xdebug: https://pecl.php.net/package/xdebug
 ARG XDEBUG_VERSION=3.5.3
-# Latest version of pcov: https://packagist.org/packages/pecl/pcov
+# Latest version of pcov: https://pecl.php.net/package/pcov
 ARG PCOV_VERSION=1.0.12
 
 RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -2,7 +2,7 @@
 # check=error=true
 
 # Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
-FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of PHP base image: https://hub.docker.com/_/php/tags
 FROM php:8.4.22-fpm-trixie AS runtime

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
+# Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
+FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+
 # Latest version of PHP base image: https://hub.docker.com/_/php/tags
 FROM php:8.4.22-fpm-trixie AS runtime
 
@@ -26,7 +29,7 @@ ARG PHP_AMQP_VERSION=2.2.0
 
 WORKDIR /var/www
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         apt-transport-https \
@@ -73,7 +76,7 @@ ARG XDEBUG_VERSION=3.5.3
 # Latest version of pcov: https://packagist.org/packages/pecl/pcov
 ARG PCOV_VERSION=1.0.12
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         vim \

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -2,7 +2,7 @@
 # check=error=true
 
 # Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
-FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of FrankenPHP base image: https://hub.docker.com/r/dunglas/frankenphp/tags
 FROM dunglas/frankenphp:1.12.4-php8.4.22-trixie AS runtime

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -18,13 +18,13 @@ ENV XDG_DATA_HOME=$XDG_DATA_HOME
 ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
-# Latest version of event-extension: https://packagist.org/packages/osmanov/pecl-event
+# Latest version of event-extension: https://pecl.php.net/package/event
 ARG PHP_EVENT_VERSION=3.1.4
-# Latest version of igbinary-extension: https://packagist.org/packages/igbinary/igbinary
+# Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
-# Latest version of redis-extension: https://packagist.org/packages/phpredis/phpredis
+# Latest version of redis-extension: https://pecl.php.net/package/redis
 ARG PHP_REDIS_VERSION=6.3.0
-# Latest version of amqp-extension: https://packagist.org/packages/php-amqp/php-amqp
+# Latest version of amqp-extension: https://pecl.php.net/package/amqp
 ARG PHP_AMQP_VERSION=2.2.0
 
 # Default to classic mode (no workers). To enable worker mode, set:
@@ -76,9 +76,9 @@ FROM runtime AS builder
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Latest version of Xdebug: https://packagist.org/packages/xdebug/xdebug
+# Latest version of Xdebug: https://pecl.php.net/package/xdebug
 ARG XDEBUG_VERSION=3.5.3
-# Latest version of pcov: https://packagist.org/packages/pecl/pcov
+# Latest version of pcov: https://pecl.php.net/package/pcov
 ARG PCOV_VERSION=1.0.12
 
 RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
+# Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
+FROM mlocati/php-extension-installer:2.11.9 AS php_extension_installer
+
 # Latest version of FrankenPHP base image: https://hub.docker.com/r/dunglas/frankenphp/tags
 FROM dunglas/frankenphp:1.12.4-php8.4.22-trixie AS runtime
 
@@ -30,7 +33,7 @@ ENV FRANKENPHP_CONFIG=""
 
 WORKDIR /var/www
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         apt-transport-https \
@@ -78,7 +81,7 @@ ARG XDEBUG_VERSION=3.5.3
 # Latest version of pcov: https://packagist.org/packages/pecl/pcov
 ARG PCOV_VERSION=1.0.12
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:2.11.9,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         vim \


### PR DESCRIPTION
## Summary
- Moved mlocati/php-extension-installer to FROM so we get dependabot updates
- Updated mlocati/php-extension-installer version
- Updated links from packagist to pecl