### PR TITLE
Scope Dependabot ignores, name a group per dependency, update images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,25 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "php"
+        update-types: ["version-update:semver-minor"]
     groups:
       php:
-        group-by: dependency-name
+        patterns:
+          - "php"
+      frankenphp:
+        patterns:
+          - "dunglas/frankenphp"
+      php-extension-installer:
+        patterns:
+          - "mlocati/php-extension-installer"
+      composer:
+        patterns:
+          - "composer/composer"
+      node:
+        patterns:
+          - "node"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,7 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
       php:
-        patterns:
-          - "*"
+        group-by: dependency-name
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -19,7 +19,7 @@ ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
 # Latest version of event-extension: https://pecl.php.net/package/event
-ARG PHP_EVENT_VERSION=3.1.4
+ARG PHP_EVENT_VERSION=3.1.6
 # Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
 # Latest version of redis-extension: https://pecl.php.net/package/redis

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -2,7 +2,7 @@
 # check=error=true
 
 # Latest version of php-extension-installer: https://hub.docker.com/r/mlocati/php-extension-installer/tags
-FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
+FROM {{ getenv "PHP_EXTENSION_INSTALLER_IMAGE" }} AS php_extension_installer
 
 # Latest version of {{ .image_label }}: {{ .image_url }}
 FROM {{ getenv "BASE_IMAGE" }} AS runtime
@@ -70,7 +70,7 @@ COPY files/general /
 {{ if .is_frankenphp -}}
 COPY files/frankenphp /
 {{ end }}
-FROM composer/composer:2.10.2-bin AS composer
+FROM {{ getenv "COMPOSER_IMAGE" }} AS composer
 
 FROM runtime AS builder
 
@@ -154,7 +154,7 @@ EOF
 
 COPY --from=composer /composer /usr/bin/composer
 
-FROM node:24.16.0-trixie-slim AS node
+FROM {{ getenv "NODE_IMAGE" }} AS node
 
 FROM builder AS builder_nodejs
 

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -154,6 +154,7 @@ EOF
 
 COPY --from=composer /composer /usr/bin/composer
 
+# Latest version of node: https://hub.docker.com/_/node/tags
 FROM {{ getenv "NODE_IMAGE" }} AS node
 
 FROM builder AS builder_nodejs

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -150,12 +150,21 @@ tasks:
     vars:
       BASE_IMAGE:
         sh: awk '/^FROM .* AS runtime$/ { print $2; exit }' {{.VARIANT}}/Dockerfile
+      PHP_EXTENSION_INSTALLER_IMAGE:
+        sh: awk '/^FROM .* AS php_extension_installer$/ { print $2; exit }' {{.VARIANT}}/Dockerfile
+      COMPOSER_IMAGE:
+        sh: awk '/^FROM .* AS composer$/ { print $2; exit }' {{.VARIANT}}/Dockerfile
+      NODE_IMAGE:
+        sh: awk '/^FROM .* AS node$/ { print $2; exit }' {{.VARIANT}}/Dockerfile
     cmds:
       - docker run
         --rm
         --volume $(pwd)/Dockerfile.tmpl:/input/Dockerfile.tmpl:ro
         --volume $(pwd)/variants/{{.VARIANT}}.yaml:/input/variant.yaml:ro
         --env "BASE_IMAGE={{.BASE_IMAGE}}"
+        --env "PHP_EXTENSION_INSTALLER_IMAGE={{.PHP_EXTENSION_INSTALLER_IMAGE}}"
+        --env "COMPOSER_IMAGE={{.COMPOSER_IMAGE}}"
+        --env "NODE_IMAGE={{.NODE_IMAGE}}"
         hairyhenderson/gomplate:{{.GOMPLATE_TAG_VERSION}}
         --context .=file:///input/variant.yaml
         --file /input/Dockerfile.tmpl

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -148,6 +148,7 @@ EOF
 
 COPY --from=composer /composer /usr/bin/composer
 
+# Latest version of node: https://hub.docker.com/_/node/tags
 FROM node:24.16.0-trixie-slim AS node
 
 FROM builder AS builder_nodejs

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -149,7 +149,7 @@ EOF
 COPY --from=composer /composer /usr/bin/composer
 
 # Latest version of node: https://hub.docker.com/_/node/tags
-FROM node:24.16.0-trixie-slim AS node
+FROM node:24.19.0-trixie-slim AS node
 
 FROM builder AS builder_nodejs
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -19,7 +19,7 @@ ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
 # Latest version of event-extension: https://pecl.php.net/package/event
-ARG PHP_EVENT_VERSION=3.1.4
+ARG PHP_EVENT_VERSION=3.1.6
 # Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
 # Latest version of redis-extension: https://pecl.php.net/package/redis

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -5,7 +5,7 @@
 FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of PHP base image: https://hub.docker.com/_/php/tags
-FROM php:8.4.23-apache-trixie AS runtime
+FROM php:8.4.24-apache-trixie AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -148,6 +148,7 @@ EOF
 
 COPY --from=composer /composer /usr/bin/composer
 
+# Latest version of node: https://hub.docker.com/_/node/tags
 FROM node:24.16.0-trixie-slim AS node
 
 FROM builder AS builder_nodejs

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -149,7 +149,7 @@ EOF
 COPY --from=composer /composer /usr/bin/composer
 
 # Latest version of node: https://hub.docker.com/_/node/tags
-FROM node:24.16.0-trixie-slim AS node
+FROM node:24.19.0-trixie-slim AS node
 
 FROM builder AS builder_nodejs
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -19,7 +19,7 @@ ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
 # Latest version of event-extension: https://pecl.php.net/package/event
-ARG PHP_EVENT_VERSION=3.1.4
+ARG PHP_EVENT_VERSION=3.1.6
 # Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
 # Latest version of redis-extension: https://pecl.php.net/package/redis

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -5,7 +5,7 @@
 FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of PHP base image: https://hub.docker.com/_/php/tags
-FROM php:8.4.23-fpm-trixie AS runtime
+FROM php:8.4.24-fpm-trixie AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -19,7 +19,7 @@ ARG XDG_CACHE_HOME=/cache
 ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
 # Latest version of event-extension: https://pecl.php.net/package/event
-ARG PHP_EVENT_VERSION=3.1.4
+ARG PHP_EVENT_VERSION=3.1.6
 # Latest version of igbinary-extension: https://pecl.php.net/package/igbinary
 ARG PHP_IGBINARY_VERSION=3.2.17RC1
 # Latest version of redis-extension: https://pecl.php.net/package/redis

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -5,7 +5,7 @@
 FROM mlocati/php-extension-installer:2.11.12 AS php_extension_installer
 
 # Latest version of FrankenPHP base image: https://hub.docker.com/r/dunglas/frankenphp/tags
-FROM dunglas/frankenphp:1.12.4-php8.4.23-trixie AS runtime
+FROM dunglas/frankenphp:1.12.7-php8.4.24-trixie AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -153,6 +153,7 @@ EOF
 
 COPY --from=composer /composer /usr/bin/composer
 
+# Latest version of node: https://hub.docker.com/_/node/tags
 FROM node:24.16.0-trixie-slim AS node
 
 FROM builder AS builder_nodejs

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -154,7 +154,7 @@ EOF
 COPY --from=composer /composer /usr/bin/composer
 
 # Latest version of node: https://hub.docker.com/_/node/tags
-FROM node:24.16.0-trixie-slim AS node
+FROM node:24.19.0-trixie-slim AS node
 
 FROM builder AS builder_nodejs
 


### PR DESCRIPTION
Ports all changes from [specsnl/php85#64](https://github.com/specsnl/php85/pull/64), [#67](https://github.com/specsnl/php85/pull/67), [#68](https://github.com/specsnl/php85/pull/68) and [#69](https://github.com/specsnl/php85/pull/69), with version strings adapted to PHP 8.4.

- Give each Docker dependency its own Dependabot pull request
- Derive pinned image versions from the generated Dockerfiles
- Updated PHP event extension (3.1.4 → 3.1.6)
- Added latest version link to Docker Hub
- Scope Dependabot ignores and name a group per dependency
- Bump the node group across 3 directories with 1 update (24.16.0 → 24.19.0)
- Updated frankenphp docker tag version (`1.12.4-php8.4.23-trixie` → `1.12.7-php8.4.24-trixie`)
- Bump the php group across 2 directories with 1 update (`8.4.23` → `8.4.24`, fpm and apache)

FrankenPHP 1.12.7 is the latest release and the newest PHP 8.4 patch it ships is 8.4.24, which is also the latest `php:8.4.x-*-trixie` tag — so all three variants land on PHP 8.4.24 together.

### Verification

- `task generate` reproduces all three Dockerfiles byte-identically from the template.
- `task lint` (hadolint) passes on all three variants.
- `.github/dependabot.yml` and `Dockerfile.tmpl` are byte-identical to php85's `main`.